### PR TITLE
Simplify stats: streak card only

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@
 
 ![GitHub Streak](https://streak-stats.demolab.com/?user=j2teamnnl&theme=tokyonight&hide_border=true)
 
-![Trophies](https://github-profile-trophy.vercel.app/?username=j2teamnnl&theme=tokyonight&no-frame=true&column=6&margin-w=8)
-
 </div>
 
 ---


### PR DESCRIPTION
Remove trophies card. Stats section now shows only the streak card — clean and working.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTpCrq9xW3ZmJPyeoGCiFZ)_