### PR TITLE
Cleanup: dedup profile views, hide unknown editor, fix title

### DIFF
--- a/.github/workflows/development-stats.yml
+++ b/.github/workflows/development-stats.yml
@@ -22,5 +22,5 @@ jobs:
           SHOW_COMMIT: "False"
           SHOW_DAYS_OF_WEEK: "True"
           SHOW_LANGUAGE_PER_REPO: "False"
-          SHOW_EDITORS: "True"
+          SHOW_EDITORS: "False"
           SHOW_SHORT_INFO: "False"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <div align="center">
 
-[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=28&pause=1000&color=58A6FF&center=true&vCenter=true&width=600&lines=Hi%2C+I'm+J2TeamNNL+%F0%9F%91%8B;Senior+Backend+Engineer;Laravel+%C2%B7+Vue+%C2%B7+AI-Augmented+Dev;I+share...+a+lot!)](https://github.com/j2teamnnl)
+[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=28&pause=1000&color=58A6FF&center=true&vCenter=true&width=600&lines=Hi%2C+I'm+J2TeamNNL+%F0%9F%91%8B;Fullstack+Engineer;Laravel+%C2%B7+Vue+%C2%B7+AI-Augmented+Dev;I+share...+a+lot!)](https://github.com/j2teamnnl)
 
-![Profile Views](https://komarev.com/ghpvc/?username=j2teamnnl&label=Profile%20Views&color=58A6FF&style=for-the-badge)
 
 </div>
 
@@ -33,8 +32,6 @@
 </p>
 
 ---
-
-### 📊 GitHub Stats
 
 <div align="center">
 


### PR DESCRIPTION
- Remove duplicate komarev profile-views badge (waka already has one)
- Remove `### 📊 GitHub Stats` heading (single streak card doesn't need a title)
- `SHOW_EDITORS: False` in workflow → hides Unknown Editor on next waka run
- Typing SVG: "Senior Backend Engineer" → "Fullstack Engineer"

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTpCrq9xW3ZmJPyeoGCiFZ)_