### PR TITLE
Add React to tech stack and typing header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=28&pause=1000&color=58A6FF&center=true&vCenter=true&width=600&lines=Hi%2C+I'm+J2TeamNNL+%F0%9F%91%8B;Fullstack+Engineer;Laravel+%C2%B7+Vue+%C2%B7+AI-Augmented+Dev;I+share...+a+lot!)](https://github.com/j2teamnnl)
+[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=28&pause=1000&color=58A6FF&center=true&vCenter=true&width=600&lines=Hi%2C+I'm+J2TeamNNL+%F0%9F%91%8B;Fullstack+Engineer;Laravel+%C2%B7+Vue+%C2%B7+React;AI-Augmented+Dev+%F0%9F%A4%96;I+share...+a+lot!)](https://github.com/j2teamnnl)
 
 
 </div>
@@ -26,6 +26,7 @@
 <p align="left">
   <img src="https://img.shields.io/badge/Laravel-FF2D20?style=for-the-badge&logo=laravel&logoColor=white" alt="Laravel" />
   <img src="https://img.shields.io/badge/Vue.js-4FC08D?style=for-the-badge&logo=vuedotjs&logoColor=white" alt="Vue.js" />
+  <img src="https://img.shields.io/badge/React-61DAFB?style=for-the-badge&logo=react&logoColor=black" alt="React" />
   <img src="https://img.shields.io/badge/MariaDB-003545?style=for-the-badge&logo=mariadb&logoColor=white" alt="MariaDB" />
   <img src="https://img.shields.io/badge/Elasticsearch-005571?style=for-the-badge&logo=elasticsearch&logoColor=white" alt="Elasticsearch" />
   <img src="https://img.shields.io/badge/Claude%20%2B%20MCP-D97757?style=for-the-badge&logo=anthropic&logoColor=white" alt="Claude + MCP" />


### PR DESCRIPTION
- Add React badge after Vue.js in tech stack
- Update typing SVG: add `Laravel · Vue · React` and `AI-Augmented Dev 🤖` lines

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTpCrq9xW3ZmJPyeoGCiFZ)_