### PR TITLE
Move social badges under title, add LinkedIn, fix description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 ![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=28&pause=1000&color=58A6FF&center=true&vCenter=true&width=600&lines=Hi%2C+I'm+J2TeamNNL+%F0%9F%91%8B;Fullstack+Engineer;Laravel+%C2%B7+Vue+%C2%B7+React;AI-Augmented+Dev+%F0%9F%A4%96;I+share...+a+lot!)
 
+<p>
+  <a href="https://fb.me/j2teamnnl"><img src="https://img.shields.io/badge/Facebook-1877F2?style=for-the-badge&logo=facebook&logoColor=white" alt="Facebook" /></a>
+  <a href="https://www.linkedin.com/in/j2teamnnl"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
+  <a href="https://www.youtube.com/j2teamnnl"><img src="https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white" alt="YouTube" /></a>
+</p>
+
 </div>
 
 ---
 
-> Just a Geek ⚡
-
-<p align="left">
-  <a href="https://fb.me/j2teamnnl"><img src="https://img.shields.io/badge/Facebook-1877F2?style=for-the-badge&logo=facebook&logoColor=white" alt="Facebook" /></a>
-  <a href="https://www.youtube.com/j2teamnnl"><img src="https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white" alt="YouTube" /></a>
-</p>
+Just a Geek ⚡
 
 [<img src="https://spotify-playing-git-master.j2teamnnl.vercel.app/api/spotify-playing" alt="J2TeamNNL Spotify Playing" width="350" />](https://open.spotify.com/user/31ghget3jspvgpjwbv5pcwli3smab)
 


### PR DESCRIPTION
- Social badges (Facebook, LinkedIn, YouTube) moved inside the header `div`, directly under the typing SVG
- Add LinkedIn badge (j2teamnnl)
- "Just a Geek ⚡" changed from blockquote to plain text

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTpCrq9xW3ZmJPyeoGCiFZ)_